### PR TITLE
Voici un petit correctif pour que le graphe continue de s'afficher en https.

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -9,8 +9,8 @@
 <link rel="author" href="https://plus.google.com/108697477633201807305/" />
 <link rel="shortcut icon" type="image/png" href="favicon.png" />
 <link rel="stylesheet" href="css/screen.css" type="text/css" media="screen">
-<script type="text/javascript" src="http://www.google.com/jsapi"></script>
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+<script type="text/javascript" src="//www.google.com/jsapi"></script>
+<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
 <script type="text/javascript" src="js/charts.js"></script>
 </head>
 <script type="text/javascript">
@@ -82,7 +82,7 @@
               src="http://www.android.com/images/brand/get_it_on_play_logo_large.png" width="172" height="60" /></a></li>
           <li><a href="https://play.google.com/store/apps/details?id=org.pixmob.freemobile.netstat">
               <img
-              src="http://chart.apis.google.com/chart?cht=qr&chs=100x100&chl=https%3A//play.google.com/store/apps/details%3Fid%3Dorg.pixmob.freemobile.netstat&chld=H|0"
+              src="//chart.apis.google.com/chart?cht=qr&chs=100x100&chl=https%3A//play.google.com/store/apps/details%3Fid%3Dorg.pixmob.freemobile.netstat&chld=H|0"
               width="100" height="100" alt="Installer Free Mobile Netstat sur Android" />
           </a></li>
         </ul>


### PR DESCRIPTION
Use protocol-relative uris to prevent mixed content failures.

Firefox blocks mixed active content when the
security.mixed_content.block_active_content
preference is enabled.

Chrome has a similar feature enabled by default.
